### PR TITLE
stop mutating options prop in react component

### DIFF
--- a/src/Cleave.react.js
+++ b/src/Cleave.react.js
@@ -70,9 +70,11 @@ var cleaveReactClass = CreateReactClass({
             options = {};
         }
 
-        options.initValue = value;
-
-        owner.properties = DefaultProperties.assign({}, options);
+        owner.properties = DefaultProperties.assign(
+            {},
+            Object.assign({}, options, { initValue: value })
+        );
+      
 
         return {
             value: owner.properties.result,

--- a/src/Cleave.react.js
+++ b/src/Cleave.react.js
@@ -72,6 +72,7 @@ var cleaveReactClass = CreateReactClass({
 
         owner.properties = DefaultProperties.assign(
             {},
+            // avoid mutating the `options` prop directly
             Object.assign({}, options, { initValue: value })
         );
       


### PR DESCRIPTION
This fixes a bug where the react component will mutate the options object it gets as a prop, which is strongly frowned upon and can cause strange behavior when you expect this object to be readonly.

Some context for Mercury folks about why we needed to do this:

We sometimes use `options` as a key to force `Cleave` to remount when `options` change. This is useful because `Cleave` seems to only read `options` on mount, and not dynamically, but sometimes we want the `options` to change over time. It looks like the library mutates this prop, however, which is an anti-pattern and can cause issues when the same `options` object is used on multiple `Cleave` instances rendered at the same time